### PR TITLE
Clean up the formatting of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@ Redcar Coffeescript Plug9in
 
 A little plugin to let you hack on coffeescript
 
-###What does it do?
+### What does it do?
 
- - Adds in the tmbundle, scans for coffeescript classes and declarations ands them to tags so Go To Tag works
+ - Adds in the tmbundle, scans for coffeescript classes and declarations, and adds them to tags so Go To Tag works.
 
-###How do I install it?
+### How do I install it?
 
-<code>
     cd ~/.redcar/plugins
     git clone git@github.com:superchris/redcar-coffeesscript.git coffeescript
     git submodule init
     git submodule update
     rm ~/.redcar/cache/textmate_bundles.cache
-    Restart redcar (to force reload of tm bundle)
-</code>
+
+Restart redcar (to force reload of tm bundle)


### PR DESCRIPTION
- The installation commands are visible on a single line currently. Fixed this to show each command on a separate line. 
- Typo in "what does it do" fixed.
